### PR TITLE
Fix Clients' events prop configs

### DIFF
--- a/node/index.ts
+++ b/node/index.ts
@@ -13,6 +13,8 @@ import { Clients } from './clients'
 import { event } from './events/onAppInstalled'
 import { test } from './routes/test'
 
+const TREE_SECONDS_MS = 3 * 1000
+const CONCURRENCY = 10
 const TIMEOUT_MS = 2500
 
 // Create a LRU memory cache for the Status client.
@@ -30,6 +32,14 @@ const clients: ClientsConfig<Clients> = {
     default: {
       retries: 3,
       timeout: TIMEOUT_MS,
+    },
+    events: {
+      exponentialTimeoutCoefficient: 2,
+      exponentialBackoffCoefficient: 2,
+      initialBackoffDelay: 50,
+      retries: 1,
+      timeout: TREE_SECONDS_MS,
+      concurrency: CONCURRENCY,
     },
     // This key will be merged with the default options and add this cache to our Status client.
     status: {


### PR DESCRIPTION
Boa tarde Rafael! Como vai?

Sei que com um leve atraso, mas me deparei com [este seu post](https://community.vtex.com/t/receiving-events-when-an-app-is-installed/33484/11) no community e reparei que, de acordo com [este curso](https://learn.vtex.com/docs/course-service-course-step03events-lang-en) do Learn, faltou o snippet adicional da PR para seus Clients conseguirem lidar com o Evento emitido pelo Apps.

Não cheguei a testar, mas acredito que funcione. Se prosseguir com a implementação, não esqueça de parsear o evento no handler e conferir se de fato foi seu App quem o triggeou, pois outros apps no mesmo workspace podem também utilizar o Apps Client como broadcaster de eventos.

Abs.,